### PR TITLE
fix: G18/G19 I/J/K mapping causing incorrect arc paths

### DIFF
--- a/media/g_code_parser.js
+++ b/media/g_code_parser.js
@@ -330,17 +330,14 @@ function parseGCode(
         centerB = resolved.center.B;
         sweepOverride = resolved.sweep;
       } else {
+        const offsetFor = (key) => key === "I" ? iVal : key === "J" ? jVal : kVal;
         const relCenter = {
-          A:
-            currentPosition[axisA] +
-            (iKey === "I" ? iVal : jKey === "I" ? iVal : kVal),
-          B:
-            currentPosition[axisB] +
-            (jKey === "J" ? jVal : iKey === "J" ? jVal : kVal),
+          A: currentPosition[axisA] + offsetFor(iKey),
+          B: currentPosition[axisB] + offsetFor(jKey),
         };
         const absCenter = {
-          A: iKey === "I" ? iVal : jKey === "I" ? iVal : kVal,
-          B: jKey === "J" ? jVal : iKey === "J" ? jVal : kVal,
+          A: offsetFor(iKey),
+          B: offsetFor(jKey),
         };
 
         if (!centerMode && !firstArcDetected.used) {

--- a/media/g_code_parser.js
+++ b/media/g_code_parser.js
@@ -288,18 +288,18 @@ function parseGCode(
 
       let axisA = "X",
         axisB = "Y",
-        iKey = "I",
-        jKey = "J";
+        keyA = "I",
+        keyB = "J";
       if (plane === "G18") {
         axisA = "Z";
         axisB = "X";
-        iKey = "K";
-        jKey = "I";
+        keyA = "K";
+        keyB = "I";
       } else if (plane === "G19") {
         axisA = "Y";
         axisB = "Z";
-        iKey = "J";
-        jKey = "K";
+        keyA = "J";
+        keyB = "K";
       }
 
       const startA = currentPosition[axisA];
@@ -332,12 +332,12 @@ function parseGCode(
       } else {
         const offsetFor = (key) => key === "I" ? iVal : key === "J" ? jVal : kVal;
         const relCenter = {
-          A: currentPosition[axisA] + offsetFor(iKey),
-          B: currentPosition[axisB] + offsetFor(jKey),
+          A: currentPosition[axisA] + offsetFor(keyA),
+          B: currentPosition[axisB] + offsetFor(keyB),
         };
         const absCenter = {
-          A: offsetFor(iKey),
-          B: offsetFor(jKey),
+          A: offsetFor(keyA),
+          B: offsetFor(keyB),
         };
 
         if (!centerMode && !firstArcDetected.used) {


### PR DESCRIPTION
In `parseGCode`, the I/J/K offset lookup for arc centers was hard-coded around G17 conventions. For G18 (`iKey='K', jKey='I'`) and G19 (`iKey='J', jKey='K'`) the conditional chains routed the wrong parameter to the wrong axis, producing arcs with incorrect centers and typically a major-arc sweep instead of the minor.

Starting at `(X=0.5, Z=0.55)`:

```
  (Bore1)                                                                                                                                                                                     
  N8115 G1 X0.5 Y1.925 F500.                                                                                                                                                                  
  N8120 G0 Z1.4                                                                                                                                                                               
  N8125 Z0.58                                                                                                                                                                                 
  N8130 G1 Z0.55 F92.                                                                                                                                                                         
  N8130 G1 Z0.55 F92.                                                                                                                                                                         
  N8135 G18 G3 X0.45 Z0.5 I-0.05 K0.                                                                                                                                                          
  N8140 G1 X0.425                                                                                                                                                                             
```
The G18 G3 Arc is drawn as 270 degrees rather than 90 degrees, and the centre is not as specified by I, K  
Renders as a 270° sweep around `(X=0.5, Z=0.5)` instead of a 90° sweep around `(X=0.45, Z=0.55)`.

The is a segment from the https://ncviewer.com/ test file/logo, which now renders correctly.
https://ncviewer.com/nc-samples/NCViewerDemo.nc

<img width="1475" height="721" alt="image" src="https://github.com/user-attachments/assets/deb53dde-f400-4732-9b07-3aebf73681b0" />

Vs. the previous code

<img width="1486" height="837" alt="image" src="https://github.com/user-attachments/assets/e84963bc-7a3c-4d65-a14a-a91caed890c7" />


## Fix
Replace the conditional chains with a small `offsetFor(key)` helper that maps `'I'/'J'/'K'` to `iVal/jVal/kVal`. `iKey`/`jKey` then index the right parameter for each plane axis.
